### PR TITLE
Update VoteSite editor for current VotingPlugin config

### DIFF
--- a/.github/.ci-trigger
+++ b/.github/.ci-trigger
@@ -1,1 +1,0 @@
-Trigger GitHub Actions after workflow merge.

--- a/.github/.ci-trigger
+++ b/.github/.ci-trigger
@@ -1,0 +1,1 @@
+Trigger GitHub Actions after workflow merge.

--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/VoteSitesConfig.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/VoteSitesConfig.java
@@ -44,11 +44,9 @@ public class VoteSitesConfig extends YmlConfigHandler {
 		int size = 180 + map.size() * 30;
 
 		VoteSitesConfig config = this;
-
 		editorFrame.setSize(300, size);
 
 		AddRemoveEditor addRemoveEditor = new AddRemoveEditor(editorFrame.getWidth()) {
-
 			@Override
 			public void onItemRemove(String name) {
 				remove("VoteSites." + name);
@@ -59,22 +57,18 @@ public class VoteSitesConfig extends YmlConfigHandler {
 
 			@Override
 			public void onItemAdd(String name) {
-				if (map.containsKey(name)) {
-					JOptionPane.showMessageDialog(panel, "VoteSite already exists");
-
-				} else {
-					name = name.replaceAll(".", "_");
-					set("VoteSites." + name + ".Enabled", true);
-					set("VoteSites." + name + ".VoteDelay", 24);
-					set("VoteSites." + name + ".Name", name);
-					set("VoteSites." + name + ".DisplayItem.Material", "DIAMOND");
-					set("VoteSites." + name + ".DisplayItem.Amount", 1);
-					set("VoteSites." + name + ".VoteURL", "http://www.example.com");
-					set("VoteSites." + name + ".ServiceSite", "PLEASE SET");
-					set("VoteSites." + name + ".Rewards.Messages.Player", "You voted");
-
-					save();
+				String identifier = sanitizeVoteSiteIdentifier(name);
+				if (identifier.isEmpty()) {
+					JOptionPane.showMessageDialog(panel,
+							"VoteSite name must contain at least one letter, number, underscore, or hyphen.");
+					return;
 				}
+				if (map.containsKey(identifier)) {
+					JOptionPane.showMessageDialog(panel, "VoteSite already exists");
+					return;
+				}
+
+				addVoteSite(identifier, identifier, "http://www.example.com", "PLEASE SET");
 				editorFrame.dispose();
 				openEditorGUI();
 			}
@@ -115,22 +109,18 @@ public class VoteSitesConfig extends YmlConfigHandler {
 
 					SwingUtilities.invokeLater(() -> {
 						loadingDialog.dispose();
-						String selectedPreset = (String) JOptionPane.showInputDialog(panel, "Select a VoteSite to add:",
-								"Add VoteSite from Preset", JOptionPane.PLAIN_MESSAGE, null, presets,
-								presets.length > 0 ? presets[0] : null);
+						String selectedPreset = (String) JOptionPane.showInputDialog(panel,
+								"Select a VoteSite to add:", "Add VoteSite from Preset", JOptionPane.PLAIN_MESSAGE,
+								null, presets, presets.length > 0 ? presets[0] : null);
 						if (selectedPreset != null && !selectedPreset.isEmpty()) {
-							String name = selectedPreset.replaceAll("\\.", "_").replaceAll("\"", "");
-							set("VoteSites." + name + ".Enabled", true);
-							set("VoteSites." + name + ".VoteDelay", 24);
-							set("VoteSites." + name + ".Name", name);
-							set("VoteSites." + name + ".DisplayItem.Material", "DIAMOND");
-							set("VoteSites." + name + ".DisplayItem.Amount", 1);
-							set("VoteSites." + name + ".VoteURL", selectedPreset.replace("\"", ""));
-							set("VoteSites." + name + ".ServiceSite",
+							String cleanPreset = selectedPreset.replace("\"", "");
+							String identifier = sanitizeVoteSiteIdentifier(cleanPreset);
+							if (identifier.isEmpty() || map.containsKey(identifier)) {
+								JOptionPane.showMessageDialog(panel, "Unable to add preset: invalid or duplicate name");
+								return;
+							}
+							addVoteSite(identifier, identifier, cleanPreset,
 									serviceSiteHandler.getServiceSites().get(selectedPreset).replace("\"", ""));
-							set("VoteSites." + name + ".Rewards.Messages.Player", "You voted");
-
-							save();
 							editorFrame.dispose();
 							openEditorGUI();
 						}
@@ -151,10 +141,8 @@ public class VoteSitesConfig extends YmlConfigHandler {
 		panel.add(addFromPresetButton);
 		panel.add(addRemoveEditor.getRemoveButton("Remove VoteSite", "Remove VoteSite",
 				PanelUtils.convertSetToArray(map.keySet())));
-
 		panel.add(Box.createRigidArea(new Dimension(0, 15)));
 
-		// Add the new button for EverySiteReward
 		JButton everySiteRewardButton = new JButton("Edit EverySiteReward");
 		everySiteRewardButton.setHorizontalAlignment(SwingConstants.CENTER);
 		everySiteRewardButton
@@ -162,7 +150,6 @@ public class VoteSitesConfig extends YmlConfigHandler {
 		everySiteRewardButton.setAlignmentY(Component.CENTER_ALIGNMENT);
 		everySiteRewardButton.addActionListener(event -> {
 			new RewardEditor(get("EverySiteReward"), "EverySiteReward") {
-
 				@Override
 				public void saveChanges(Map<String, Object> changes) {
 					try {
@@ -200,9 +187,7 @@ public class VoteSitesConfig extends YmlConfigHandler {
 			};
 		});
 		panel.add(everySiteRewardButton);
-
 		panel.add(Box.createRigidArea(new Dimension(0, 15)));
-
 		addRemoveEditor.getOptionsButtons(panel, PanelUtils.convertSetToArray(map.keySet()));
 
 		editorFrame.add(panel);
@@ -210,4 +195,23 @@ public class VoteSitesConfig extends YmlConfigHandler {
 		editorFrame.setVisible(true);
 	}
 
+	private void addVoteSite(String identifier, String displayName, String voteUrl, String serviceSite) {
+		set("VoteSites." + identifier + ".Enabled", true);
+		set("VoteSites." + identifier + ".VoteDelay", "24h");
+		set("VoteSites." + identifier + ".Name", displayName);
+		set("VoteSites." + identifier + ".DisplayItem.Material", "DIAMOND");
+		set("VoteSites." + identifier + ".DisplayItem.Amount", 1);
+		set("VoteSites." + identifier + ".VoteURL", voteUrl);
+		set("VoteSites." + identifier + ".ServiceSite", serviceSite);
+		set("VoteSites." + identifier + ".Rewards.Messages.Player", "You voted");
+		save();
+	}
+
+	private static String sanitizeVoteSiteIdentifier(String name) {
+		if (name == null) {
+			return "";
+		}
+		return name.trim().replaceAll("[\\s.]+", "_").replaceAll("[^A-Za-z0-9_-]", "")
+				.replaceAll("_+", "_").replaceAll("^_+|_+$", "");
+	}
 }

--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/votesites/VoteSiteEditor.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/votesites/VoteSiteEditor.java
@@ -32,8 +32,8 @@ import com.bencodez.votingplugineditor.files.VoteSitesConfig;
 
 public class VoteSiteEditor {
 
-	private List<SettingButton> buttons;
-	private String siteName;
+	private final List<SettingButton> buttons;
+	private final String siteName;
 
 	public VoteSiteEditor(VoteSitesConfig voteSitesConfig, String siteName) {
 		Map<String, Object> siteData = (Map<String, Object>) voteSitesConfig.get("VoteSites." + siteName,
@@ -46,27 +46,20 @@ public class VoteSiteEditor {
 	private void createAndShowGUI(String siteName, Map<String, Object> siteData, VoteSitesConfig voteSitesConfig) {
 		JFrame frame = new JFrame("VoteSite Editor - " + siteName);
 		frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-		frame.setSize(500, 400);
+		frame.setSize(550, 500);
 		frame.setLayout(new BorderLayout());
 
 		JTabbedPane tabbedPane = new JTabbedPane();
-
-		JPanel mainPanel = createMainPanel(siteName, siteData, voteSitesConfig);
-		tabbedPane.addTab("Main", mainPanel);
-
-		JPanel advancedPanel = createAdvancedOptionsPanel(siteData, voteSitesConfig);
-		tabbedPane.addTab("Advanced Options", advancedPanel);
-
+		tabbedPane.addTab("Main", createMainPanel(siteName, siteData, voteSitesConfig));
+		tabbedPane.addTab("Advanced Options", createAdvancedOptionsPanel(siteData, voteSitesConfig));
 		frame.add(tabbedPane, BorderLayout.CENTER);
 
 		JButton saveButton = new JButton("Save and Apply Changes");
 		saveButton.setAlignmentX(Component.CENTER_ALIGNMENT);
 		saveButton.addActionListener(e -> saveChanges(siteName, voteSitesConfig));
-
 		frame.add(saveButton, BorderLayout.SOUTH);
 
 		PanelUtils.adjustSettingButtonsMaxWidth(buttons);
-
 		frame.setLocationRelativeTo(null);
 		frame.setVisible(true);
 	}
@@ -77,18 +70,12 @@ public class VoteSiteEditor {
 		panel.setBorder(BorderFactory.createEmptyBorder(15, 15, 15, 15));
 
 		buttons.add(new BooleanSettingButton(panel, "Enabled", siteData, "VoteSite Enabled:"));
-
 		panel.add(Box.createVerticalStrut(10));
-
 		buttons.add(new StringSettingButton(panel, "Name", siteData, "Display Name", voteSiteName));
-
 		buttons.add(new StringSettingButton(panel, "ServiceSite", siteData, "Service Site:", "NOT SET"));
-
 		buttons.add(new StringSettingButton(panel, "VoteURL", siteData, "Voting URL:", "NOT SET"));
+		buttons.add(new StringSettingButton(panel, "VoteDelay", siteData, "Vote Delay:", "24h"));
 
-		buttons.add(new IntSettingButton(panel, "VoteDelay", siteData, "VoteDelay:", 24));
-
-		JPanel panel1 = new JPanel();
 		JButton rewardsEdit = new JButton("Edit Rewards");
 		rewardsEdit.setHorizontalAlignment(SwingConstants.CENTER);
 		rewardsEdit.setMaximumSize(new Dimension(Integer.MAX_VALUE, rewardsEdit.getPreferredSize().height));
@@ -100,19 +87,8 @@ public class VoteSiteEditor {
 				public void saveChanges(Map<String, Object> changes) {
 					try {
 						for (Entry<String, Object> change : changes.entrySet()) {
-							boolean isInt = false;
-							try {
-								Integer.parseInt((String) change.getValue());
-								isInt = true;
-							} catch (Exception e) {
-							}
-							if (isInt) {
-								voteSitesConfig.set("VoteSites." + voteSiteName + ".Rewards." + change.getKey(),
-										Integer.parseInt((String) change.getValue()));
-							} else {
-								voteSitesConfig.set("VoteSites." + voteSiteName + ".Rewards." + change.getKey(),
-										change.getValue());
-							}
+							voteSitesConfig.set("VoteSites." + voteSiteName + ".Rewards." + change.getKey(),
+									change.getValue());
 						}
 						voteSitesConfig.save();
 						JOptionPane.showMessageDialog(null, "Changes have been saved.");
@@ -147,9 +123,7 @@ public class VoteSiteEditor {
 		});
 
 		panel.add(rewardsEdit);
-
 		panel.add(Box.createVerticalStrut(10));
-
 		return panel;
 	}
 
@@ -159,19 +133,22 @@ public class VoteSiteEditor {
 		advancedPanel.setBorder(BorderFactory.createTitledBorder("Advanced Options"));
 
 		buttons.add(new BooleanSettingButton(advancedPanel, "WaitUntilVoteDelay", siteData, "Wait Until Vote Delay:",
-				false, "Blocks votes with VoteDelay"));
-		buttons.add(new BooleanSettingButton(advancedPanel, "VoteDelayDaily", siteData, "VoteDelayDaily:", false,
-				"VoteDelay is daily instead of hourly"));
-		buttons.add(new BooleanSettingButton(advancedPanel, "ForceOffline", siteData, "ForceOffline:", false,
-				"Forces runs rewards while player is offline"));
+				false, "Blocks votes until the configured VoteDelay has passed"));
+		buttons.add(new BooleanSettingButton(advancedPanel, "VoteDelayDaily", siteData, "Vote Delay Daily:", false,
+				"Reset the vote delay at a fixed time each day"));
+		buttons.add(new IntSettingButton(advancedPanel, "VoteDelayDailyHour", siteData, "Vote Delay Daily Hour:", 1,
+				"Server hour from 1-24 used when VoteDelayDaily is enabled"));
+		buttons.add(new BooleanSettingButton(advancedPanel, "ForceOffline", siteData, "Force Offline:", false,
+				"Run this site's rewards while the player is offline; this changes offline vote handling"));
 		buttons.add(new BooleanSettingButton(advancedPanel, "Hidden", siteData, "Hidden:", false,
-				"(Hide votesite in GUI's and from counters)"));
+				"Hide this VoteSite from supported GUIs and counters"));
+		buttons.add(new StringSettingButton(advancedPanel, "PermissionToView", siteData, "Permission To View:", ""));
 		buttons.add(new IntSettingButton(advancedPanel, "Priority", siteData, "Priority:", 5,
-				"Used to orders sites in VoteURL GUI"));
+				"Higher-priority sites appear earlier in sorted VoteSite lists"));
 		buttons.add(new StringSettingButton(advancedPanel, "DisplayItem.Material", siteData, "Display Item Material",
-				"DIAMOND", PanelUtils.convertListToArray(VotingPluginEditor.getMaterials()), "Used in certain GUI's"));
+				"DIAMOND", PanelUtils.convertListToArray(VotingPluginEditor.getMaterials()), "Used in supported GUIs"));
 		buttons.add(new IntSettingButton(advancedPanel, "DisplayItem.Amount", siteData, "Display Item Amount:", 1,
-				"Used in certain GUI's"));
+				"Used in supported GUIs"));
 
 		JButton coolDownEndRewardsEdit = new JButton("Edit CoolDownEndRewards");
 		coolDownEndRewardsEdit.setHorizontalAlignment(SwingConstants.CENTER);
@@ -185,19 +162,8 @@ public class VoteSiteEditor {
 				public void saveChanges(Map<String, Object> changes) {
 					try {
 						for (Entry<String, Object> change : changes.entrySet()) {
-							boolean isInt = false;
-							try {
-								Integer.parseInt((String) change.getValue());
-								isInt = true;
-							} catch (Exception e) {
-							}
-							if (isInt) {
-								voteSitesConfig.set("VoteSites." + siteName + ".CoolDownEndRewards." + change.getKey(),
-										Integer.parseInt((String) change.getValue()));
-							} else {
-								voteSitesConfig.set("VoteSites." + siteName + ".CoolDownEndRewards." + change.getKey(),
-										change.getValue());
-							}
+							voteSitesConfig.set("VoteSites." + siteName + ".CoolDownEndRewards." + change.getKey(),
+									change.getValue());
 						}
 						voteSitesConfig.save();
 						JOptionPane.showMessageDialog(null, "Changes have been saved.");
@@ -231,7 +197,6 @@ public class VoteSiteEditor {
 			};
 		});
 		advancedPanel.add(coolDownEndRewardsEdit);
-
 		return advancedPanel;
 	}
 
@@ -242,15 +207,12 @@ public class VoteSiteEditor {
 				changes.put(button.getKey(), button.getValue());
 				button.updateValue();
 			}
-
 		}
 
-		// Notify & save changes
 		if (!changes.isEmpty()) {
 			try {
 				for (Entry<String, Object> change : changes.entrySet()) {
 					voteSitesConfig.set("VoteSites." + voteSiteName + "." + change.getKey(), change.getValue());
-
 				}
 				voteSitesConfig.save();
 				JOptionPane.showMessageDialog(null, "Changes have been saved.");


### PR DESCRIPTION
## What changed

- Fix manual VoteSite name sanitization so `.` no longer matches and replaces every character.
- Sanitize spaces, dots, quotes, and unsupported YAML/path characters before creating a site.
- Validate the sanitized identifier before checking for duplicates or writing configuration.
- Centralize VoteSite creation so manual and preset creation use the same defaults.
- Write new VoteSite delays as `24h`, matching the current VotingPlugin configuration format.
- Change the VoteDelay editor from an integer control to a string control so duration values can be preserved.
- Add editing support for `VoteDelayDailyHour` and `PermissionToView`.
- Clarify advanced-option descriptions, especially `ForceOffline`.
- Stop coercing reward values based on whether a string happens to parse as an integer; preserve the value supplied by the reward editor.

## Why

VotingPluginEditor was using an unescaped `replaceAll(".", "_")` call for manually created VoteSites. Since `.` matches every character in a regular expression, names could be converted entirely to underscores. The editor also treated `VoteDelay` as an integer even though current VotingPlugin defaults use duration strings such as `24h`.

## Impact

New and edited VoteSites now follow the current VotingPlugin schema more closely and avoid creating broken identifiers. Existing numeric VoteDelay values can still be loaded as configuration data, while users can save modern duration values.

## Validation

- Compared the branch against `main`; only `VoteSitesConfig.java` and `VoteSiteEditor.java` are changed.
- Reviewed generated configuration paths against the current VotingPlugin `VoteSites.yml` defaults.
- Local Maven execution was not available in the current environment, so CI/build validation remains required.