### PR TITLE
Prevent checkbox rows from clipping controls

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/settng/BooleanSettingButton.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/settng/BooleanSettingButton.java
@@ -61,7 +61,7 @@ public class BooleanSettingButton implements SettingButton {
 
 	@Override
 	public boolean hasChanged() {
-		return !checkBox.isSelected() == initialValue;
+		return checkBox.isSelected() != initialValue;
 	}
 
 	@Override
@@ -86,8 +86,9 @@ public class BooleanSettingButton implements SettingButton {
 		if (isWidthSet) {
 			return;
 		}
-		checkBox.setMaximumSize(new Dimension(width + 50, checkBox.getPreferredSize().height));
-		checkBox.setPreferredSize(new Dimension(width, checkBox.getPreferredSize().height));
+		int controlWidth = width + 50;
+		checkBox.setMaximumSize(new Dimension(controlWidth, checkBox.getPreferredSize().height));
+		checkBox.setPreferredSize(new Dimension(controlWidth, checkBox.getPreferredSize().height));
 		isWidthSet = true;
 	}
 
@@ -99,5 +100,4 @@ public class BooleanSettingButton implements SettingButton {
 	public boolean isSelected() {
 		return checkBox.isSelected();
 	}
-
 }


### PR DESCRIPTION
## What changed

- Use the same expanded width for both the preferred and maximum checkbox sizes.
- Simplify boolean change detection to a direct comparison.

## Why

The checkbox row reserved extra maximum width for the checkbox indicator but kept a smaller preferred width, which could clip the control or crowd its label in aligned settings panels.

## Validation

GitHub Actions will run the Maven build for this pull request.