### PR TITLE
Keep blank double fields unchanged

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/settng/DoubleSettingButton.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/settng/DoubleSettingButton.java
@@ -70,15 +70,17 @@ public class DoubleSettingButton implements SettingButton {
 
 	@Override
 	public boolean hasChanged() {
-		return !textField.getText().equals("" + initialValue);
+		String value = textField.getText().trim();
+		return !value.isEmpty() && !value.equals("" + initialValue);
 	}
 
 	@Override
 	public Object getValue() {
-		if (textField.getText().isEmpty()) {
-			return 0;
+		String value = textField.getText().trim();
+		if (value.isEmpty()) {
+			return initialValue;
 		}
-		return Double.parseDouble(textField.getText());
+		return Double.parseDouble(value);
 	}
 
 	@Override


### PR DESCRIPTION
## What changed

- Trim double input before comparing or parsing it.
- Treat a blank double field as unchanged.
- Preserve the existing value when a blank field is read.

## Why

Clearing a decimal setting currently causes the editor to save `0`, which can silently alter configuration values.

## Validation

GitHub Actions will run the Maven build for this pull request.