### PR TITLE
Save blank string lists as empty

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/settng/StringListSettingButton.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/settng/StringListSettingButton.java
@@ -68,7 +68,11 @@ public class StringListSettingButton implements SettingButton {
 
 	@Override
 	public Object getValue() {
-		return textArea.getText().split("\n");
+		String value = textArea.getText();
+		if (value.trim().isEmpty()) {
+			return new String[0];
+		}
+		return value.split("\\R");
 	}
 
 	@Override


### PR DESCRIPTION
## What changed

- Save a completely blank list field as an empty array.
- Split non-empty list fields on any line-ending format.

## Why

A blank list editor currently saves `['']` instead of `[]`, leaving a phantom empty command or value in the YAML.

## Validation

GitHub Actions will run the Maven build for this pull request.