### PR TITLE
Hide string-list scroll panes with settings

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/settng/StringListSettingButton.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/settng/StringListSettingButton.java
@@ -26,6 +26,8 @@ public class StringListSettingButton implements SettingButton {
 
 	private JTextArea textArea;
 
+	private JScrollPane scrollPane;
+
 	private JLabel label;
 
 	public StringListSettingButton(JPanel panel, String key, Map<String, Object> data, String labelText) {
@@ -50,7 +52,7 @@ public class StringListSettingButton implements SettingButton {
 		textArea = new JTextArea(initialValue);
 		textArea.setLineWrap(true);
 		textArea.setWrapStyleWord(true);
-		JScrollPane scrollPane = new JScrollPane(textArea);
+		scrollPane = new JScrollPane(textArea);
 		scrollPane.setPreferredSize(new Dimension(150, 70));
 		scrollPane.setMaximumSize(new Dimension(Integer.MAX_VALUE, 200));
 
@@ -89,7 +91,7 @@ public class StringListSettingButton implements SettingButton {
 	
 	public void setVisible(boolean visible) {
         label.setVisible(visible);
-        textArea.setVisible(visible);
+        scrollPane.setVisible(visible);
 	}
 
 	@Override


### PR DESCRIPTION
## What changed

- Keep a reference to the list field's `JScrollPane`.
- Hide and show the complete scroll container instead of only the inner text area.

## Why

Calling `setVisible(false)` currently hides the text area but leaves an empty scroll-pane frame visible in the settings panel.

## Validation

GitHub Actions will run the Maven build for this pull request.