### PR TITLE
Import local Config editor updates

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/ConfigConfig.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/ConfigConfig.java
@@ -19,6 +19,7 @@ import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
 
+import com.bencodez.votingplugineditor.api.edit.add.AddRemoveEditor;
 import com.bencodez.votingplugineditor.api.edit.rewards.RewardEditor;
 import com.bencodez.votingplugineditor.api.misc.PanelUtils;
 import com.bencodez.votingplugineditor.api.misc.YmlConfigHandler;
@@ -28,6 +29,13 @@ import com.bencodez.votingplugineditor.api.settng.SettingButton;
 import com.bencodez.votingplugineditor.api.settng.StringSettingButton;
 import com.bencodez.votingplugineditor.api.sftp.SFTPSettings;
 
+/**
+ * Editor UI handler for VotingPlugin's {@code Config.yml}.
+ * <p>
+ * This class builds the Swing panels used by VotingPluginEditor to edit core plugin settings.
+ * Updated for VotingPlugin 7.0+ layout (Database section, VoteReminders, VoteBroadcast).
+ * </p>
+ */
 public class ConfigConfig extends YmlConfigHandler {
 	private final List<SettingButton> settingButtons;
 
@@ -48,8 +56,8 @@ public class ConfigConfig extends YmlConfigHandler {
 		JPanel mainPanel = createMainEditorPanel();
 		tabbedPane.addTab("Main Settings", mainPanel);
 
-		JPanel voteRemindingPanel = createVoteRemindingPanel();
-		tabbedPane.addTab("Vote Reminding", voteRemindingPanel);
+		JPanel voteRemindingPanel = createVoteRemindersPanel();
+		tabbedPane.addTab("Vote Reminders", voteRemindingPanel);
 
 		JPanel formattingPanel = createFormattingPanel();
 		tabbedPane.addTab("Formatting Settings", formattingPanel);
@@ -80,6 +88,21 @@ public class ConfigConfig extends YmlConfigHandler {
 
 		panel.add(createDatabaseSettingsPanel());
 
+		settingButtons.add(new BooleanSettingButton(panel, "AutoCreateVoteSites", getConfigData(), "Auto Create VoteSites"));
+		settingButtons.add(new StringSettingButton(panel, "BedrockPlayerPrefix", getConfigData(), "Bedrock Player Prefix", "."));
+		settingButtons.add(new BooleanSettingButton(panel, "OnlineMode", getConfigData(), "Online Mode"));
+		settingButtons.add(new BooleanSettingButton(panel, "UseVoteGUIMainCommand", getConfigData(), "Use VoteGUI Main Command"));
+		settingButtons.add(new BooleanSettingButton(panel, "CreateBackups", getConfigData(), "Create Backups"));
+		settingButtons.add(new BooleanSettingButton(panel, "LoadCommandAliases", getConfigData(), "Load Command Aliases"));
+		settingButtons.add(new IntSettingButton(panel, "PointsOnVote", getConfigData(), "Points On Vote", 0));
+		settingButtons.add(new BooleanSettingButton(panel, "CaseInsensitiveYMLFiles", getConfigData(), "Case Insensitive YML Files"));
+		settingButtons.add(new BooleanSettingButton(panel, "LimitMonthlyVotes", getConfigData(), "Limit Monthly Votes"));
+		settingButtons.add(new BooleanSettingButton(panel, "TreatVanishAsOffline", getConfigData(), "Treat Vanish As Offline"));
+		settingButtons.add(new StringSettingButton(panel, "DelayLoginEvent", getConfigData(), "Delay Login Event (e.g. 0s)", "0s"));
+		settingButtons.add(new BooleanSettingButton(panel, "WaitUntilLoggedIn", getConfigData(), "Wait Until Logged In"));
+		settingButtons.add(new BooleanSettingButton(panel, "PerSiteCoolDownEvents", getConfigData(), "Per-Site Cooldown Events"));
+		settingButtons.add(new BooleanSettingButton(panel, "QueueVotesDuringTimeChange", getConfigData(), "Queue Votes During Time Change"));
+
 		settingButtons.add(new BooleanSettingButton(panel, "AdvancedServiceSiteHandling", getConfigData(),
 				"Advanced Service Site Handling"));
 		settingButtons.add(new BooleanSettingButton(panel, "StoreMonthTotalsWithDate", getConfigData(),
@@ -103,33 +126,37 @@ public class ConfigConfig extends YmlConfigHandler {
 		formattingPanel.setLayout(new BoxLayout(formattingPanel, BoxLayout.Y_AXIS));
 		formattingPanel.setBorder(BorderFactory.createTitledBorder("Formatting Settings"));
 
-		ArrayList<SettingButton> settingButtons = new ArrayList<SettingButton>();
+		ArrayList<SettingButton> localButtons = new ArrayList<SettingButton>();
 
-		settingButtons.add(new StringSettingButton(formattingPanel, "Format.HelpLine", getConfigData(), "Help Line",
-				"&6%Command% - &6%HelpMessage%"));
-		settingButtons.add(new StringSettingButton(formattingPanel, "Format.BroadcastMsg", getConfigData(),
-				"Broadcast Message", "&6[&4Broadcast&6] &2Thanks &c%player% &2for voting on %SiteName%"));
+		localButtons.add(new StringSettingButton(formattingPanel, "Format.HelpLine", getConfigData(), "Help Line", ""));
+		localButtons.add(new StringSettingButton(formattingPanel, "Format.TimeFormat", getConfigData(), "Time Format", ""));
+		localButtons.add(new StringSettingButton(formattingPanel, "Format.RewardTimeFormat", getConfigData(),
+				"Reward Time Format", ""));
 
-		BooleanSettingButton onlyOneOfflineBroadcastButton = new BooleanSettingButton(formattingPanel,
-				"Format.OnlyOneOfflineBroadcast", getConfigData(), "Only One Offline Broadcast");
-		settingButtons.add(onlyOneOfflineBroadcastButton);
+		formattingPanel.add(Box.createRigidArea(new Dimension(0, 10)));
 
-		StringSettingButton offlineBroadcastButton = new StringSettingButton(formattingPanel, "Format.OfflineBroadcast",
-				getConfigData(), "Offline Broadcast",
-				"&6[&4Broadcast&6] &2Thanks &c%player% &2for voting on %numberofvotes% times!");
-		settingButtons.add(offlineBroadcastButton);
+		JPanel broadcastPanel = new JPanel();
+		broadcastPanel.setLayout(new BoxLayout(broadcastPanel, BoxLayout.Y_AXIS));
+		broadcastPanel.setBorder(BorderFactory.createTitledBorder("Vote Broadcast"));
 
-		settingButtons.add(new BooleanSettingButton(formattingPanel, "Format.BroadcastWhenOnline", getConfigData(),
-				"Broadcast When Online"));
+		localButtons.add(new StringSettingButton(broadcastPanel, "VoteBroadcast.Type", getConfigData(),
+				"Type (EVERY_VOTE / LIST / etc.)", "EVERY_VOTE"));
+		localButtons.add(new StringSettingButton(broadcastPanel, "VoteBroadcast.Duration", getConfigData(),
+				"Duration (e.g. 2m)", "2m"));
+		localButtons.add(new IntSettingButton(broadcastPanel, "VoteBroadcast.MaxSitesListed", getConfigData(),
+				"Max Sites Listed (0 = all)", 0));
 
-		PanelUtils.adjustSettingButtonsMaxWidth(settingButtons);
-		this.settingButtons.addAll(settingButtons);
+		localButtons.add(new StringSettingButton(broadcastPanel, "VoteBroadcast.Format.BroadcastMsg", getConfigData(),
+				"Broadcast Message", ""));
+		localButtons.add(new StringSettingButton(broadcastPanel, "VoteBroadcast.Format.Header", getConfigData(),
+				"Header", ""));
+		localButtons.add(new StringSettingButton(broadcastPanel, "VoteBroadcast.Format.ListLine", getConfigData(),
+				"List Line", ""));
 
-		offlineBroadcastButton.setVisible(Boolean.TRUE.equals(getConfigData("Format.OnlyOneOfflineBroadcast")));
+		formattingPanel.add(broadcastPanel);
 
-		onlyOneOfflineBroadcastButton.addActionListener(event -> {
-			offlineBroadcastButton.setVisible(onlyOneOfflineBroadcastButton.isSelected());
-		});
+		PanelUtils.adjustSettingButtonsMaxWidth(localButtons);
+		this.settingButtons.addAll(localButtons);
 
 		return formattingPanel;
 	}
@@ -170,29 +197,100 @@ public class ConfigConfig extends YmlConfigHandler {
 		return topVoterSettingsPanel;
 	}
 
-	private JPanel createVoteRemindingPanel() {
+	private JPanel createVoteRemindersPanel() {
 		JPanel voteRemindingPanel = new JPanel();
-
-		ArrayList<SettingButton> settingButtons = new ArrayList<SettingButton>();
+		ArrayList<SettingButton> localButtons = new ArrayList<SettingButton>();
 
 		voteRemindingPanel.setLayout(new BoxLayout(voteRemindingPanel, BoxLayout.Y_AXIS));
-		voteRemindingPanel.setBorder(BorderFactory.createTitledBorder("Vote Reminding Settings"));
+		voteRemindingPanel.setBorder(BorderFactory.createTitledBorder("Vote Reminder Settings"));
 
-		settingButtons.add(new BooleanSettingButton(voteRemindingPanel, "VoteReminding.Enabled", getConfigData(),
-				"Vote Reminding Enabled"));
-		settingButtons.add(new BooleanSettingButton(voteRemindingPanel, "VoteReminding.RemindOnLogin", getConfigData(),
-				"Vote Reminding On Login"));
-		settingButtons.add(new BooleanSettingButton(voteRemindingPanel, "VoteReminding.RemindOnlyOnce", getConfigData(),
-				"Vote Reminding Only Once"));
-		settingButtons.add(new IntSettingButton(voteRemindingPanel, "VoteReminding.RemindDelay", getConfigData(),
-				"Vote Reminding Delay", 30));
+		localButtons.add(new BooleanSettingButton(voteRemindingPanel, "VoteReminderOptions.Enabled", getConfigData(),
+				"Vote Reminders Enabled"));
+		localButtons.add(new BooleanSettingButton(voteRemindingPanel, "VoteReminderOptions.StopAfterMatch", getConfigData(),
+				"Stop After First Match"));
+		localButtons.add(new StringSettingButton(voteRemindingPanel, "VoteReminderOptions.GlobalCooldown", getConfigData(),
+				"Global Cooldown (e.g. 10m)", "10m"));
+		localButtons.add(new IntSettingButton(voteRemindingPanel, "VoteReminderOptions.DefaultPriority", getConfigData(),
+				"Default Priority", 0));
 
-		voteRemindingPanel.add(Box.createVerticalStrut(10));
-		voteRemindingPanel.add(addRewardsButton("VoteReminding.Rewards", "Edit Vote Reminding Rewards"));
-		voteRemindingPanel.add(Box.createVerticalStrut(10));
+		voteRemindingPanel.add(Box.createRigidArea(new Dimension(0, 10)));
 
-		PanelUtils.adjustSettingButtonsMaxWidth(settingButtons);
-		this.settingButtons.addAll(settingButtons);
+		JPanel remindersPanel = new JPanel();
+		remindersPanel.setLayout(new BoxLayout(remindersPanel, BoxLayout.Y_AXIS));
+		remindersPanel.setBorder(BorderFactory.createTitledBorder("VoteReminders"));
+
+		AddRemoveEditor addRemoveEditor = new AddRemoveEditor(remindersPanel.getWidth()) {
+			@Override
+			public void onItemRemove(String name) {
+				remove("VoteReminders." + name);
+				save();
+				openEditorGUI();
+			}
+
+			@Override
+			public void onItemAdd(String name) {
+				set("VoteReminders." + name + ".Type", "LOGIN");
+				set("VoteReminders." + name + ".Priority", 50);
+				set("VoteReminders." + name + ".Delay", "3s");
+				set("VoteReminders." + name + ".Cooldown", "3m");
+				set("VoteReminders." + name + ".Rewards.Messages.Player",
+						"&aYou can vote! Sites left: &e%sitesavailable%&a.");
+				save();
+				openEditorGUI();
+			}
+
+			@Override
+			public void onItemSelect(String name) {
+				JFrame reminderFrame = new JFrame("Editing VoteReminder - " + name);
+				reminderFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+				reminderFrame.setSize(650, 650);
+				reminderFrame.setLayout(new BorderLayout());
+
+				JPanel settingsPanel = new JPanel();
+				settingsPanel.setLayout(new BoxLayout(settingsPanel, BoxLayout.Y_AXIS));
+				settingsPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+				ArrayList<SettingButton> buttons = new ArrayList<SettingButton>();
+
+				buttons.add(new StringSettingButton(settingsPanel, "VoteReminders." + name + ".Type", getConfigData(),
+						"Type (LOGIN / FIRSTJOIN / INTERVAL / ANYSITE_COOLDOWN / ALLSITES_COOLDOWN)", "LOGIN"));
+				buttons.add(new IntSettingButton(settingsPanel, "VoteReminders." + name + ".Priority", getConfigData(),
+						"Priority", 0));
+				buttons.add(new StringSettingButton(settingsPanel, "VoteReminders." + name + ".Delay", getConfigData(),
+						"Delay (optional, e.g. 3s)", ""));
+				buttons.add(new StringSettingButton(settingsPanel, "VoteReminders." + name + ".Interval", getConfigData(),
+						"Interval (for INTERVAL, e.g. 30m)", ""));
+				buttons.add(new StringSettingButton(settingsPanel, "VoteReminders." + name + ".Cooldown", getConfigData(),
+						"Cooldown (e.g. 2h)", "0s"));
+
+				settingsPanel.add(Box.createRigidArea(new Dimension(0, 10)));
+				settingsPanel.add(addRewardsButton("VoteReminders." + name + ".Rewards", "Edit Rewards"));
+
+				PanelUtils.adjustSettingButtonsMaxWidth(buttons);
+				ConfigConfig.this.settingButtons.addAll(buttons);
+
+				JButton saveButton = new JButton("Save and Apply Changes");
+				saveButton.addActionListener(e -> saveChanges());
+
+				reminderFrame.add(settingsPanel, BorderLayout.CENTER);
+				reminderFrame.add(saveButton, BorderLayout.SOUTH);
+				reminderFrame.setLocationRelativeTo(null);
+				reminderFrame.setVisible(true);
+			}
+		};
+
+		String[] list = PanelUtils
+				.convertSetToArray(((Map<String, Object>) get("VoteReminders", new HashMap<String, Object>())).keySet());
+
+		remindersPanel.add(addRemoveEditor.getAddButton("Add VoteReminder", "Add VoteReminder"));
+		remindersPanel.add(addRemoveEditor.getRemoveButton("Remove VoteReminder", "Remove VoteReminder", list));
+		remindersPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+		addRemoveEditor.getOptionsButtons(remindersPanel, list);
+
+		voteRemindingPanel.add(remindersPanel);
+
+		PanelUtils.adjustSettingButtonsMaxWidth(localButtons);
+		this.settingButtons.addAll(localButtons);
 
 		return voteRemindingPanel;
 	}
@@ -248,7 +346,6 @@ public class ConfigConfig extends YmlConfigHandler {
 		rewardsEdit.setAlignmentY(Component.CENTER_ALIGNMENT);
 		rewardsEdit.addActionListener(event -> {
 			new RewardEditor(getConfigData(path), path) {
-
 				@Override
 				public void saveChanges(Map<String, Object> changes) {
 					try {


### PR DESCRIPTION
## What changed

- Import the uncommitted local `ConfigConfig.java` updates.
- Add current VotingPlugin main settings such as automatic VoteSite creation, Bedrock prefix, online mode, backups, command aliases, points, YAML case handling, login timing and vote queue options.
- Add the current `VoteBroadcast` editor section.
- Add full named `VoteReminders.*` creation, removal, selection and reward editing.
- Preserve the already-merged `Database.*` paths, username field and database type options.

## Reconciliation

The uploaded local file was based partly on older editor code. Before importing it, the database section was reconciled with current `main` so this PR does not restore the retired `MySQL.*` paths or hardcoded sample credentials.

`PanelUtils.java` is intentionally excluded because its changes were committed directly to `main` by the repository owner.

The larger local `SpecialRewardsConfig.java` update will be handled separately so the milestones/streak changes can be reviewed independently.

## Validation

GitHub Actions will run the Maven build for this pull request.