### PR TITLE
Avoid local file truncation during SFTP saves

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/misc/YmlConfigHandler.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/misc/YmlConfigHandler.java
@@ -182,14 +182,14 @@ public abstract class YmlConfigHandler {
     }
 
     public void save() {
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
-            DumperOptions opts = new DumperOptions();
-            opts.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-            opts.setPrettyFlow(true);
-            opts.setIndent(2);
-            Yaml yaml = new Yaml(opts);
+        DumperOptions opts = new DumperOptions();
+        opts.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        opts.setPrettyFlow(true);
+        opts.setIndent(2);
+        Yaml yaml = new Yaml(opts);
 
-            StringBuilder out = new StringBuilder();
+        StringBuilder out = new StringBuilder();
+        try {
             for (Map.Entry<String,Object> e : configData.entrySet()) {
                 writeYaml(out, yaml, e.getKey(), e.getValue(), 0, "");
             }
@@ -203,7 +203,9 @@ public abstract class YmlConfigHandler {
                     computeRemotePath(),
                     out.toString());
             } else {
-                writer.write(out.toString());
+                try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
+                    writer.write(out.toString());
+                }
             }
         } catch (IOException ex) {
             throw new RuntimeException("Failed to save config: " + filePath, ex);
@@ -303,18 +305,18 @@ public abstract class YmlConfigHandler {
     }
     
     public Object get(Map<String, Object> configData, String path, Object defaultValue) {
-		String[] keys = path.split("\\.");
-		Map<String, Object> current = configData;
-		for (int i = 0; i < keys.length - 1; i++) {
-			Object nested = current.get(keys[i]);
-			if (nested instanceof Map) {
-				current = (Map<String, Object>) nested;
-			} else {
-				return defaultValue;
-			}
-		}
-		return current.getOrDefault(keys[keys.length - 1], defaultValue);
-	}
+        String[] keys = path.split("\\.");
+        Map<String, Object> current = configData;
+        for (int i = 0; i < keys.length - 1; i++) {
+            Object nested = current.get(keys[i]);
+            if (nested instanceof Map) {
+                current = (Map<String, Object>) nested;
+            } else {
+                return defaultValue;
+            }
+        }
+        return current.getOrDefault(keys[keys.length - 1], defaultValue);
+    }
 
     @SuppressWarnings("unchecked")
     public void set(String path, Object value) {


### PR DESCRIPTION
## What changed

- Build the YAML output before selecting the save destination.
- Open a local `FileWriter` only for local saves.
- Keep SFTP saves entirely remote.

## Why

`save()` previously opened `filePath` in a try-with-resources block before checking `useSFTP()`. That could create or truncate a local file even when the editor was configured to save only through SFTP, and it could make a valid remote save fail because the local path was unavailable.

## Impact

Remote config editing no longer depends on a writable local path and no longer modifies a local file as a side effect.

## Validation

GitHub Actions will run the Maven build for this pull request.