### PR TITLE
Save remote reward files in Rewards folder

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/RewardFilesConfig.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/RewardFilesConfig.java
@@ -8,23 +8,28 @@ import com.bencodez.votingplugineditor.api.misc.YmlConfigHandler;
 import com.bencodez.votingplugineditor.api.sftp.SFTPSettings;
 
 public class RewardFilesConfig extends YmlConfigHandler {
-	// private final List<SettingButton> settingButtons;
 	private final String name;
 
 	public RewardFilesConfig(String filePath, String name, String votingPluginDirectory, SFTPSettings sftp) {
-		super(filePath, votingPluginDirectory, sftp);
+		super(filePath, getRewardDirectory(votingPluginDirectory, sftp), sftp);
 		this.name = name;
-		// settingButtons = new ArrayList<SettingButton>();
 		openEditorGUI();
 	}
 
 	public RewardFilesConfig(String filePath, String name, boolean open, String votingPluginDirectory,
 			SFTPSettings sftp) {
-		super(filePath, votingPluginDirectory, sftp);
+		super(filePath, getRewardDirectory(votingPluginDirectory, sftp), sftp);
 		this.name = name;
 		if (open) {
 			openEditorGUI();
 		}
+	}
+
+	private static String getRewardDirectory(String votingPluginDirectory, SFTPSettings sftp) {
+		if (sftp != null && sftp.isEnabled()) {
+			return votingPluginDirectory + "/Rewards";
+		}
+		return votingPluginDirectory;
 	}
 
 	@Override


### PR DESCRIPTION
## What changed

- Treat the VotingPlugin `Rewards` directory as the remote base path when editing reward files over SFTP.
- Keep local reward-file behavior unchanged.

## Why

Reward files are stored under `plugins/VotingPlugin/Rewards`. The editor downloaded files from that folder but `RewardFilesConfig` later saved them relative to the plugin root, so an edited remote reward could be written to the wrong path.

## Compatibility impact

SFTP reward-file editing now matches VotingPlugin's current reward-file layout.

## Validation

GitHub Actions will run the Maven build.