### PR TITLE
Use current defaults for generated VoteSites

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/VoteSitesConfig.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/VoteSitesConfig.java
@@ -68,7 +68,7 @@ public class VoteSitesConfig extends YmlConfigHandler {
 					return;
 				}
 
-				addVoteSite(identifier, identifier, "http://www.example.com", "PLEASE SET");
+				addVoteSite(identifier, identifier, "link to vote URL here, used in /vote", "PLEASE SET");
 				editorFrame.dispose();
 				openEditorGUI();
 			}
@@ -196,7 +196,7 @@ public class VoteSitesConfig extends YmlConfigHandler {
 	}
 
 	private void addVoteSite(String identifier, String displayName, String voteUrl, String serviceSite) {
-		set("VoteSites." + identifier + ".Enabled", true);
+		set("VoteSites." + identifier + ".Enabled", false);
 		set("VoteSites." + identifier + ".VoteDelay", "24h");
 		set("VoteSites." + identifier + ".Name", displayName);
 		set("VoteSites." + identifier + ".DisplayItem.Material", "DIAMOND");


### PR DESCRIPTION
## What changed

- Create new VoteSites with `Enabled: false`, matching current VotingPlugin defaults.
- Use the current placeholder VoteURL wording from VoteSites.yml.
- Keep current duration, DisplayItem, ServiceSite, and inline reward defaults.

## Why

VotingPlugin's current VoteSites.yml defaults new/example sites to disabled so incomplete placeholder entries do not become active accidentally. The editor currently enabled every newly generated site immediately.

## Compatibility impact

Generated VoteSites now match the current resource schema and safer activation behavior.

## Validation

GitHub Actions will run the Maven build.