### PR TITLE
Add current VoteURL GUI editor

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/GUIConfig.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/GUIConfig.java
@@ -61,26 +61,19 @@ public class GUIConfig extends YmlConfigHandler {
 		panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
 		Map<String, Object> data = getConfigData();
+		String[] standardMethods = { "CHAT", "CHEST", "DIALOG" };
 
 		panel.add(PanelUtils.createSectionLabel("GUIMethod"));
-		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Today", data, "Today GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST" }));
-		settingButtons.add(new StringSettingButton(panel, "GUIMethod.TopVoter", data, "TopVoter GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST" }));
-		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Last", data, "Last GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST" }));
-		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Next", data, "Next GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST" }));
-		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Total", data, "Total GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST" }));
+		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Today", data, "Today GUI Method", "CHEST", standardMethods));
+		settingButtons.add(new StringSettingButton(panel, "GUIMethod.TopVoter", data, "TopVoter GUI Method", "CHEST", standardMethods));
+		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Last", data, "Last GUI Method", "CHEST", standardMethods));
+		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Next", data, "Next GUI Method", "CHEST", standardMethods));
+		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Total", data, "Total GUI Method", "CHEST", standardMethods));
 		settingButtons.add(new StringSettingButton(panel, "GUIMethod.URL", data, "VoteURL GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST", "BOOK" }));
-		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Best", data, "Best GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST" }));
-		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Streak", data, "Streak GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST" }));
-		settingButtons.add(new StringSettingButton(panel, "GUIMethod.GUI", data, "Main GUI Method", "CHEST",
-				new String[] { "CHAT", "CHEST" }));
+				new String[] { "CHAT", "CHEST", "BOOK", "DIALOG" }));
+		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Best", data, "Best GUI Method", "CHEST", standardMethods));
+		settingButtons.add(new StringSettingButton(panel, "GUIMethod.Streak", data, "Streak GUI Method", "CHEST", standardMethods));
+		settingButtons.add(new StringSettingButton(panel, "GUIMethod.GUI", data, "Main GUI Method", "CHEST", standardMethods));
 
 		settingButtons.add(new BooleanSettingButton(panel, "LastMonthGUI", data, "Enable LastMonthGUI:"));
 
@@ -126,10 +119,8 @@ public class GUIConfig extends YmlConfigHandler {
 
 		panel.add(createItemEditorButton("CHEST.VoteURL.AlreadyVotedItem", "Edit Already Voted Item"));
 		panel.add(createItemEditorButton("CHEST.VoteURL.CanVoteItem", "Edit Can Vote Item"));
-		panel.add(createItemEditorButton("CHEST.VoteURL.AllUrlsButton.AlreadyVotedItem",
-				"Edit All URLs Already Voted Item"));
-		panel.add(createItemEditorButton("CHEST.VoteURL.AllUrlsButton.CanVoteItem",
-				"Edit All URLs Can Vote Item"));
+		panel.add(createItemEditorButton("CHEST.VoteURL.AllUrlsButton.AlreadyVotedItem", "Edit All URLs Already Voted Item"));
+		panel.add(createItemEditorButton("CHEST.VoteURL.AllUrlsButton.CanVoteItem", "Edit All URLs Can Vote Item"));
 
 		PanelUtils.adjustSettingButtonsMaxWidth(buttons);
 		frame.add(panel, BorderLayout.CENTER);
@@ -172,12 +163,9 @@ public class GUIConfig extends YmlConfigHandler {
 
 		Map<String, Object> backButtonData = (Map<String, Object>) get("CHEST.BackButton", new HashMap<String, Object>());
 		ArrayList<SettingButton> buttons = new ArrayList<SettingButton>();
-		buttons.add(new BooleanSettingButton(panel, "CHEST.BackButton.OpenVoteURL", getConfigData(),
-				"Open VoteURL when clicked"));
-		buttons.add(new BooleanSettingButton(panel, "CHEST.BackButton.EndOfGUI", getConfigData(),
-				"Place at end of GUI"));
-		buttons.add(new BooleanSettingButton(panel, "CHEST.BackButton.Exit", getConfigData(),
-				"Use as exit button"));
+		buttons.add(new BooleanSettingButton(panel, "CHEST.BackButton.OpenVoteURL", getConfigData(), "Open VoteURL when clicked"));
+		buttons.add(new BooleanSettingButton(panel, "CHEST.BackButton.EndOfGUI", getConfigData(), "Place at end of GUI"));
+		buttons.add(new BooleanSettingButton(panel, "CHEST.BackButton.Exit", getConfigData(), "Use as exit button"));
 		settingButtons.addAll(buttons);
 
 		JButton editItem = new JButton("Edit Back Button Item");
@@ -200,7 +188,6 @@ public class GUIConfig extends YmlConfigHandler {
 
 		PanelUtils.adjustSettingButtonsMaxWidth(buttons);
 		frame.add(panel, BorderLayout.CENTER);
-
 		JButton saveButton = new JButton("Save and Apply Changes");
 		saveButton.addActionListener(e -> saveChanges());
 		frame.add(saveButton, BorderLayout.SOUTH);
@@ -216,7 +203,6 @@ public class GUIConfig extends YmlConfigHandler {
 
 		JPanel panel = new JPanel();
 		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-
 		Map<String, Object> map = (Map<String, Object>) get("CHEST.VoteGUI", new HashMap<String, Object>());
 
 		AddRemoveEditor addRemoveEditor = new AddRemoveEditor(frame.getWidth()) {
@@ -262,8 +248,7 @@ public class GUIConfig extends YmlConfigHandler {
 		};
 
 		panel.add(addRemoveEditor.getAddButton("Add Item/Slot", "Add Item/Slot"));
-		panel.add(addRemoveEditor.getRemoveButton("Remove Item/Slot", "Remove Item/Slot",
-				PanelUtils.convertSetToArray(map.keySet())));
+		panel.add(addRemoveEditor.getRemoveButton("Remove Item/Slot", "Remove Item/Slot", PanelUtils.convertSetToArray(map.keySet())));
 		addRemoveEditor.getOptionsButtons(panel, PanelUtils.convertSetToArray(map.keySet()));
 
 		frame.add(panel);

--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/GUIConfig.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/GUIConfig.java
@@ -88,12 +88,76 @@ public class GUIConfig extends YmlConfigHandler {
 		editVoteGUI.addActionListener(event -> openVoteGUIEditor());
 		panel.add(editVoteGUI);
 
+		JButton editVoteURL = new JButton("Edit VoteURL GUI");
+		editVoteURL.addActionListener(event -> openVoteURLEditor());
+		panel.add(editVoteURL);
+
 		JButton editBackButton = new JButton("Edit Shared Back Button");
 		editBackButton.addActionListener(event -> openBackButtonEditor());
 		panel.add(editBackButton);
 
 		panel.add(Box.createVerticalStrut(10));
 		return panel;
+	}
+
+	private void openVoteURLEditor() {
+		JFrame frame = new JFrame("VoteURL GUI Editor");
+		frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+		frame.setSize(700, 650);
+		frame.setLayout(new BorderLayout());
+
+		JPanel panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+		ArrayList<SettingButton> buttons = new ArrayList<SettingButton>();
+		buttons.add(new StringSettingButton(panel, "CHEST.VoteURL.Name", getConfigData(), "GUI Name", "&cVoteURL"));
+		buttons.add(new BooleanSettingButton(panel, "CHEST.VoteURL.BackButton", getConfigData(), "Enable Back Button"));
+		buttons.add(new StringSettingButton(panel, "CHEST.VoteURL.SiteName", getConfigData(), "Voted Site Name", "&c%Name%"));
+		buttons.add(new StringSettingButton(panel, "CHEST.VoteURL.SiteNameCanVote", getConfigData(), "Available Site Name", "&a%Name%"));
+		buttons.add(new StringSettingButton(panel, "CHEST.VoteURL.SeeURL", getConfigData(), "See URL Text", "&cClick to see URL"));
+		buttons.add(new StringSettingButton(panel, "CHEST.VoteURL.NextVote", getConfigData(), "Next Vote Text", "&cCan Vote In: %Info%"));
+		buttons.add(new BooleanSettingButton(panel, "CHEST.VoteURL.ViewAllUrlsButtonEnabled", getConfigData(),
+				"Enable View All URLs Button"));
+		buttons.add(new BooleanSettingButton(panel, "CHEST.VoteURL.AllUrlsButton.RequireAllSitesVoted", getConfigData(),
+				"Require All Sites Voted"));
+		buttons.add(new StringSettingButton(panel, "CHEST.VoteURL.URLText", getConfigData(), "URL Click Text", "%VoteUrl%"));
+		settingButtons.addAll(buttons);
+
+		panel.add(createItemEditorButton("CHEST.VoteURL.AlreadyVotedItem", "Edit Already Voted Item"));
+		panel.add(createItemEditorButton("CHEST.VoteURL.CanVoteItem", "Edit Can Vote Item"));
+		panel.add(createItemEditorButton("CHEST.VoteURL.AllUrlsButton.AlreadyVotedItem",
+				"Edit All URLs Already Voted Item"));
+		panel.add(createItemEditorButton("CHEST.VoteURL.AllUrlsButton.CanVoteItem",
+				"Edit All URLs Can Vote Item"));
+
+		PanelUtils.adjustSettingButtonsMaxWidth(buttons);
+		frame.add(panel, BorderLayout.CENTER);
+		JButton saveButton = new JButton("Save and Apply Changes");
+		saveButton.addActionListener(e -> saveChanges());
+		frame.add(saveButton, BorderLayout.SOUTH);
+		frame.setLocationRelativeTo(null);
+		frame.setVisible(true);
+	}
+
+	private JButton createItemEditorButton(String path, String label) {
+		JButton button = new JButton(label);
+		button.addActionListener(event -> new ItemEditor((Map<String, Object>) get(path, new HashMap<String, Object>())) {
+			@Override
+			public void saveChanges(Map<String, Object> changes) {
+				for (Entry<String, Object> change : changes.entrySet()) {
+					set(path + "." + change.getKey(), change.getValue());
+				}
+				save();
+			}
+
+			@Override
+			public void removeItemPath(String subPath) {
+				remove(path + "." + subPath);
+				save();
+			}
+		});
+		return button;
 	}
 
 	private void openBackButtonEditor() {


### PR DESCRIPTION
## What changed

- Add editing for current `CHEST.VoteURL` text and behavior settings.
- Add controls for GUI name, back button, site labels, next-vote text, URL text, and the view-all-URLs button.
- Add standard item editors for available, already-voted, and all-URLs item states.

## Why

VotingPluginEditor previously exposed only the main VoteGUI item list. Current VotingPlugin GUI.yml has a substantial `CHEST.VoteURL` section that could not be configured through the editor.

## Compatibility impact

Current VoteURL GUI labels, availability items, and all-URLs behavior can now be edited directly.

## Dependency

This PR is stacked on PR #26 so the shared GUI back-button work remains intact. Merge #26 first, then this PR.

## Validation

GitHub Actions will run the Maven build.