### PR TITLE
Update item editor for current item fields

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/edit/item/ItemEditor.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/edit/item/ItemEditor.java
@@ -12,7 +12,6 @@ import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JFrame;
-import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -34,11 +33,9 @@ public abstract class ItemEditor {
 	private Map<String, Object> changes;
 
 	public ItemEditor(Map<String, Object> data) {
-		configData = data;
+		configData = data == null ? new HashMap<String, Object>() : data;
 		buttons = new ArrayList<>();
 		changes = new HashMap<String, Object>();
-
-		// Create GUI
 		createAndShowGUI();
 	}
 
@@ -54,11 +51,9 @@ public abstract class ItemEditor {
 		JButton saveButton = new JButton("Save and Apply Changes");
 		saveButton.setAlignmentX(Component.CENTER_ALIGNMENT);
 		saveButton.addActionListener(e -> saveChanges());
-
 		frame.add(saveButton, BorderLayout.SOUTH);
-		
-		PanelUtils.adjustSettingButtonsMaxWidth(buttons);
 
+		PanelUtils.adjustSettingButtonsMaxWidth(buttons);
 		frame.setLocationRelativeTo(null);
 		frame.setVisible(true);
 	}
@@ -68,21 +63,17 @@ public abstract class ItemEditor {
 		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
 		panel.setBorder(BorderFactory.createEmptyBorder(15, 15, 15, 15));
 
-		String currentMaterial = (String) configData.get("Material");
+		String currentMaterial = String.valueOf(configData.getOrDefault("Material", "STONE"));
 		buttons.add(new StringSettingButton(panel, "Material", configData, "Item material", "STONE",
 				PanelUtils.convertListToArray(VotingPluginEditor.getMaterials())));
-		// Setup SettingButtons
 		buttons.add(new IntSettingButton(panel, "Amount", configData, "Amount:", 1));
-
 		buttons.add(new StringSettingButton(panel, "Name", configData, "Item name", ""));
-
 		buttons.add(new StringListSettingButton(panel, "Lore", configData, "Lore (one per line):"));
 
 		JPanel enchantsPanel = new JPanel();
 		enchantsPanel.setLayout(new BoxLayout(enchantsPanel, BoxLayout.X_AXIS));
 
 		AddRemoveEditor enchantsEditor = new AddRemoveEditor(frame.getWidth()) {
-
 			@Override
 			public void onItemSelect(String name) {
 			}
@@ -103,10 +94,8 @@ public abstract class ItemEditor {
 
 		Map<String, Object> enchantData = (Map<String, Object>) PanelUtils.get(configData, "Enchants",
 				new HashMap<String, Object>());
-
 		enchantsPanel.add(enchantsEditor.getAddButton("Add Enchant", "Add Enchant"));
 		enchantsPanel.add(enchantsEditor.getRemoveButton("Remove Enchant", "Remove Enchant", enchantData.keySet()));
-
 		panel.add(enchantsPanel);
 		panel.add(PanelUtils.createSectionLabel("Edit Enchant (If any):"));
 
@@ -118,34 +107,32 @@ public abstract class ItemEditor {
 		buttons.add(new IntSettingButton(panel, "MinAmount", configData, "Min Amount:", 0));
 		buttons.add(new IntSettingButton(panel, "MaxAmount", configData, "Max Amount:", 0));
 		buttons.add(new IntSettingButton(panel, "Chance", configData, "Chance (% Rewards Only):", 0));
-
 		buttons.add(new BooleanSettingButton(panel, "Glow", configData, "Item Glow:"));
+		buttons.add(new BooleanSettingButton(panel, "Unbreakable", configData, "Unbreakable:"));
 		buttons.add(new IntSettingButton(panel, "CustomModelData", configData, "Custom Model Data:", 0));
+		buttons.add(new IntSettingButton(panel, "Data", configData, "Legacy Data Value:", 0));
+		buttons.add(new IntSettingButton(panel, "Damage", configData, "Item Damage:", 0));
+		buttons.add(new StringSettingButton(panel, "ItemsAdder", configData, "ItemsAdder Item ID", ""));
+		buttons.add(new StringSettingButton(panel, "Nexo", configData, "Nexo Item ID", ""));
 
-		// specific material items types
-		// player head
 		if (currentMaterial.equalsIgnoreCase("player_head")) {
 			buttons.add(new StringSettingButton(panel, "Skull", configData, "Player skull by name", ""));
-			buttons.add(new StringSettingButton(panel, "SkullTexture", configData, "Payer skull by texture", ""));
+			buttons.add(new StringSettingButton(panel, "SkullTexture", configData, "Player skull by texture", ""));
 			buttons.add(new StringSettingButton(panel, "SkullURL", configData, "Player skull by URL", ""));
 			buttons.add(new StringSettingButton(panel, "SkullUUID", configData, "Player skull by UUID", ""));
 		} else if (currentMaterial.equalsIgnoreCase("FIREWORK_ROCKET")) {
 			buttons.add(new IntSettingButton(panel, "Power", configData, "Firework power:", 0));
 		}
 
-		// Add a button to toggle the visibility of ItemFlags
 		JButton toggleItemFlagsButton = new JButton("Toggle ItemFlags");
 		toggleItemFlagsButton.setAlignmentX(Component.CENTER_ALIGNMENT);
 		panel.add(toggleItemFlagsButton);
 
 		JPanel itemFlagsPanel = new JPanel();
 		itemFlagsPanel.setLayout(new BoxLayout(itemFlagsPanel, BoxLayout.Y_AXIS));
-		itemFlagsPanel.setVisible(false); // Initially hidden
-
+		itemFlagsPanel.setVisible(false);
 		buttons.add(new StringListSettingButton(itemFlagsPanel, "ItemFlags", configData, "ItemFlags (one per line):"));
-
 		panel.add(itemFlagsPanel);
-
 		toggleItemFlagsButton.addActionListener(e -> itemFlagsPanel.setVisible(!itemFlagsPanel.isVisible()));
 
 		panel.add(PanelUtils.createSectionLabel("GUI Settings:"));
@@ -161,8 +148,6 @@ public abstract class ItemEditor {
 
 	private void saveChanges() {
 		Map<String, Object> changes = new HashMap<>();
-
-		// Check for changes
 		for (SettingButton button : buttons) {
 			if (button.hasChanged()) {
 				changes.put(button.getKey(), button.getValue());
@@ -172,8 +157,6 @@ public abstract class ItemEditor {
 
 		changes.putAll(this.changes);
 		this.changes.clear();
-
-		// Save changes if there are any
 		if (!changes.isEmpty()) {
 			saveChanges(changes);
 		}


### PR DESCRIPTION
## What changed

- Handle missing item maps and missing `Material` values safely.
- Add current AdvancedCore item fields: `Unbreakable`, `Damage`, `ItemsAdder`, and `Nexo`.
- Preserve legacy `Data` values still present in VotingPlugin GUI resources.
- Keep existing skull, firework, enchant, GUI, and reward-item settings.

## Why

VotingPluginEditor could crash when opening an item section without `Material`, and it omitted several item keys supported by the current AdvancedCore item parser. It also could not preserve legacy `Data` values still used in current VotingPlugin GUI.yml defaults.

## Validation

GitHub Actions will run the Maven build.