### PR TITLE
Preserve VoteSite preset order

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/misc/ServiceSiteHandler.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/misc/ServiceSiteHandler.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 
 import lombok.Getter;
@@ -16,7 +16,7 @@ public class ServiceSiteHandler {
 			"https://raw.githubusercontent.com/wiki/BenCodez/VotingPlugin/Minecraft-Server-Lists.md";
 
 	@Getter
-	private HashMap<String, String> serviceSites = new HashMap<>();
+	private LinkedHashMap<String, String> serviceSites = new LinkedHashMap<>();
 
 	public ServiceSiteHandler() {
 		loadFromGithub();


### PR DESCRIPTION
## What changed

- Store server-list presets in a `LinkedHashMap`.
- Preserve the order maintained in VotingPlugin's wiki when presenting presets.

## Why

The current preset loader parsed the correct source but stored entries in a `HashMap`, so the editor could present VoteSite presets in arbitrary order rather than the maintained wiki order.

## Validation

GitHub Actions will run the Maven build.