### PR TITLE
Parse only VoteSite preset list entries

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/misc/ServiceSiteHandler.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/misc/ServiceSiteHandler.java
@@ -70,9 +70,10 @@ public class ServiceSiteHandler {
 			String line;
 			while ((line = br.readLine()) != null) {
 				String trimmed = line.trim();
-				if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
-					trimmed = trimmed.substring(2).trim();
+				if (!trimmed.startsWith("- ") && !trimmed.startsWith("* ")) {
+					continue;
 				}
+				trimmed = trimmed.substring(2).trim();
 
 				String[] split = trimmed.split("\\s+-\\s+", 2);
 				if (split.length == 2 && !split[0].isBlank() && !split[1].isBlank()) {
@@ -86,6 +87,7 @@ public class ServiceSiteHandler {
 	}
 
 	private String stripMarkdown(String value) {
-		return value.trim().replace("`", "").replace("**", "");
+		return value.trim().replaceAll("\\[([^\\]]+)]\\([^)]*\\)", "$1").replace("`", "")
+				.replace("**", "");
 	}
 }


### PR DESCRIPTION
## What changed

- Parse only Markdown bullet entries from the VotingPlugin server-list wiki.
- Strip Markdown link wrappers while keeping their display text.
- Ignore headings and prose that happen to contain ` - `.

## Why

The preset parser previously treated any wiki line containing a spaced dash as a potential preset. Future documentation prose could therefore appear as an invalid VoteSite option.

## Validation

GitHub Actions will run the Maven build.