### PR TITLE
Add conditional JavaScript item setting

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/edit/item/ItemEditor.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/edit/item/ItemEditor.java
@@ -114,6 +114,8 @@ public abstract class ItemEditor {
 		buttons.add(new IntSettingButton(panel, "Damage", configData, "Item Damage:", 0));
 		buttons.add(new StringSettingButton(panel, "ItemsAdder", configData, "ItemsAdder Item ID", ""));
 		buttons.add(new StringSettingButton(panel, "Nexo", configData, "Nexo Item ID", ""));
+		buttons.add(new StringSettingButton(panel, "ConditionalJavascript", configData,
+				"Conditional JavaScript", ""));
 
 		if (currentMaterial.equalsIgnoreCase("player_head")) {
 			buttons.add(new StringSettingButton(panel, "Skull", configData, "Player skull by name", ""));


### PR DESCRIPTION
## What changed

- Add `ConditionalJavascript` to the shared item editor.
- Preserve the field alongside current material, custom-item, skull, and GUI settings.

## Why

Current AdvancedCore item parsing supports conditional JavaScript item definitions, but VotingPluginEditor could not view or edit that field.

## Validation

GitHub Actions will run the Maven build.