### PR TITLE
Handle missing EverySiteReward sections

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/VoteSitesConfig.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/files/VoteSitesConfig.java
@@ -155,7 +155,7 @@ public class VoteSitesConfig extends YmlConfigHandler {
 				.setMaximumSize(new Dimension(Integer.MAX_VALUE, everySiteRewardButton.getPreferredSize().height));
 		everySiteRewardButton.setAlignmentY(Component.CENTER_ALIGNMENT);
 		everySiteRewardButton.addActionListener(event -> {
-			new RewardEditor(get("EverySiteReward"), "EverySiteReward") {
+			new RewardEditor(asMap(get("EverySiteReward")), "EverySiteReward") {
 				@Override
 				public void saveChanges(Map<String, Object> changes) {
 					try {
@@ -178,7 +178,7 @@ public class VoteSitesConfig extends YmlConfigHandler {
 				@Override
 				public Map<String, Object> updateData() {
 					load();
-					return (Map<String, Object>) get("EverySiteReward");
+					return asMap(get("EverySiteReward"));
 				}
 
 				@Override


### PR DESCRIPTION
## What changed

- Open `EverySiteReward` through the same safe map conversion used for VoteSites.
- Return an empty reward map when the section is absent or malformed.

## Why

Current VoteSites.yml allows `EverySiteReward: {}` or removal of the section. The editor previously cast the value directly and could fail when users opened a disabled or incomplete section.

## Dependency

Stacked on PR #36.

## Validation

GitHub Actions will run the Maven build.