### PR TITLE
Add JavaScript-aware item editor adapter

### DIFF
--- a/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/edit/item/JavascriptAwareItemEditor.java
+++ b/VotingPluginEditor/src/main/java/com/bencodez/votingplugineditor/api/edit/item/JavascriptAwareItemEditor.java
@@ -1,0 +1,18 @@
+package com.bencodez.votingplugineditor.api.edit.item;
+
+import java.util.Map;
+
+import com.bencodez.votingplugineditor.api.misc.JavascriptRequirementHandler;
+import com.bencodez.votingplugineditor.api.sftp.SFTPSettings;
+
+/**
+ * Item editor variant that checks VotingPlugin's current JavaScript engine
+ * setting before saving ConditionalJavascript values.
+ */
+public abstract class JavascriptAwareItemEditor extends ItemEditor {
+
+    public JavascriptAwareItemEditor(Map<String, Object> data, String configFilePath,
+            String votingPluginDirectory, SFTPSettings sftp) {
+        super(data, new JavascriptRequirementHandler(configFilePath, votingPluginDirectory, sftp));
+    }
+}


### PR DESCRIPTION
Adds a reusable ItemEditor variant that automatically supplies the Config.yml JavaScript requirement handler. GUI, VoteSite, shop, and reward editors can migrate to this adapter without duplicating prompt setup.

Stacked on PR #39.